### PR TITLE
Update ODH component paths

### DIFF
--- a/base/operate-first/argo.yaml
+++ b/base/operate-first/argo.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: operate-first
   source:
-    path: base/argo
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/base/argo
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/base/operate-first/dashboard.yaml
+++ b/base/operate-first/dashboard.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: operate-first
   source:
-    path: base/dashboard
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/base/dashboard
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/base/operate-first/datacatalog.yaml
+++ b/base/operate-first/datacatalog.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: operate-first
   source:
-    path: base/datacatalog
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/base/datacatalog
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/base/operate-first/jupyterhub.yaml
+++ b/base/operate-first/jupyterhub.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: operate-first
   source:
-    path: base/jupyterhub
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/base/jupyterhub
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/base/operate-first/kafka.yaml
+++ b/base/operate-first/kafka.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: operate-first
   source:
-    path: base/kafka
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/base/kafka
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/base/operate-first/monitoring.yaml
+++ b/base/operate-first/monitoring.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: operate-first
   source:
-    path: base/monitoring
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/base/monitoring
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/base/operate-first/superset.yaml
+++ b/base/operate-first/superset.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: operate-first
   source:
-    path: base/superset
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/base/superset
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/overlays/crc/operate-first/argo.yaml
+++ b/overlays/crc/operate-first/argo.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-argo
 spec:
   source:
-    path: overlays/crc/argo
+    path: odh/overlays/crc/argo

--- a/overlays/crc/operate-first/dashboard.yaml
+++ b/overlays/crc/operate-first/dashboard.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-dashboard
 spec:
   source:
-    path: overlays/crc/dashboard
+    path: odh/overlays/crc/dashboard

--- a/overlays/crc/operate-first/datacatalog.yaml
+++ b/overlays/crc/operate-first/datacatalog.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-datacatalog
 spec:
   source:
-    path: overlays/crc/datacatalog
+    path: odh/overlays/crc/datacatalog

--- a/overlays/crc/operate-first/jupyterhub.yaml
+++ b/overlays/crc/operate-first/jupyterhub.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-jupyterhub
 spec:
   source:
-    path: overlays/crc/jupyterhub
+    path: odh/overlays/crc/jupyterhub

--- a/overlays/crc/operate-first/kafka.yaml
+++ b/overlays/crc/operate-first/kafka.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-kafka
 spec:
   source:
-    path: overlays/crc/kafka
+    path: odh/overlays/crc/kafka

--- a/overlays/crc/operate-first/monitoring.yaml
+++ b/overlays/crc/operate-first/monitoring.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-monitoring
 spec:
   source:
-    path: overlays/crc/monitoring
+    path: odh/overlays/crc/monitoring

--- a/overlays/crc/operate-first/odh-operator.yaml
+++ b/overlays/crc/operate-first/odh-operator.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: operate-first
   source:
-    path: overlays/crc/operator
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/overlays/crc/operator
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/overlays/crc/operate-first/superset.yaml
+++ b/overlays/crc/operate-first/superset.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-superset
 spec:
   source:
-    path: overlays/crc/superset
+    path: odh/overlays/crc/superset

--- a/overlays/moc/operate-first/argo.yaml
+++ b/overlays/moc/operate-first/argo.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-argo
 spec:
   source:
-    path: overlays/moc/argo
+    path: odh/overlays/moc/argo

--- a/overlays/moc/operate-first/dashboard.yaml
+++ b/overlays/moc/operate-first/dashboard.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-dashboard
 spec:
   source:
-    path: overlays/moc/dashboard
+    path: odh/overlays/moc/dashboard

--- a/overlays/moc/operate-first/datacatalog.yaml
+++ b/overlays/moc/operate-first/datacatalog.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-datacatalog
 spec:
   source:
-    path: overlays/moc/datacatalog
+    path: odh/overlays/moc/datacatalog

--- a/overlays/moc/operate-first/jupyterhub.yaml
+++ b/overlays/moc/operate-first/jupyterhub.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-jupyterhub
 spec:
   source:
-    path: overlays/moc/jupyterhub
+    path: odh/overlays/moc/jupyterhub

--- a/overlays/moc/operate-first/kafka.yaml
+++ b/overlays/moc/operate-first/kafka.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-kafka
 spec:
   source:
-    path: overlays/moc/kafka
+    path: odh/overlays/moc/kafka

--- a/overlays/moc/operate-first/monitoring.yaml
+++ b/overlays/moc/operate-first/monitoring.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-monitoring
 spec:
   source:
-    path: overlays/moc/monitoring
+    path: odh/overlays/moc/monitoring

--- a/overlays/moc/operate-first/superset.yaml
+++ b/overlays/moc/operate-first/superset.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-superset
 spec:
   source:
-    path: overlays/moc/superset
+    path: odh/overlays/moc/superset

--- a/overlays/quicklab/operate-first/argo.yaml
+++ b/overlays/quicklab/operate-first/argo.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-argo
 spec:
   source:
-    path: overlays/quicklab/argo
+    path: odh/overlays/quicklab/argo

--- a/overlays/quicklab/operate-first/dashboard.yaml
+++ b/overlays/quicklab/operate-first/dashboard.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-dashboard
 spec:
   source:
-    path: overlays/quicklab/dashboard
+    path: odh/overlays/quicklab/dashboard

--- a/overlays/quicklab/operate-first/datacatalog.yaml
+++ b/overlays/quicklab/operate-first/datacatalog.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-datacatalog
 spec:
   source:
-    path: overlays/quicklab/datacatalog
+    path: odh/overlays/quicklab/datacatalog

--- a/overlays/quicklab/operate-first/jupyterhub.yaml
+++ b/overlays/quicklab/operate-first/jupyterhub.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-jupyterhub
 spec:
   source:
-    path: overlays/quicklab/jupyterhub
+    path: odh/overlays/quicklab/jupyterhub

--- a/overlays/quicklab/operate-first/kafka.yaml
+++ b/overlays/quicklab/operate-first/kafka.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-kafka
 spec:
   source:
-    path: overlays/quicklab/kafka
+    path: odh/overlays/quicklab/kafka

--- a/overlays/quicklab/operate-first/monitoring.yaml
+++ b/overlays/quicklab/operate-first/monitoring.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-monitoring
 spec:
   source:
-    path: overlays/quicklab/monitoring
+    path: odh/overlays/quicklab/monitoring

--- a/overlays/quicklab/operate-first/odh-operator.yaml
+++ b/overlays/quicklab/operate-first/odh-operator.yaml
@@ -8,8 +8,8 @@ spec:
     name: in-cluster
   project: operate-first
   source:
-    path: overlays/quicklab/operator
-    repoURL: https://github.com/operate-first/odh.git
+    path: odh/overlays/quicklab/operator
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
     syncOptions:

--- a/overlays/quicklab/operate-first/superset.yaml
+++ b/overlays/quicklab/operate-first/superset.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opf-superset
 spec:
   source:
-    path: overlays/quicklab/superset
+    path: odh/overlays/quicklab/superset


### PR DESCRIPTION
Should follow [this](https://github.com/operate-first/odh/pull/64) pr, and the renaming of the odh repo. 