### PR TITLE
Remove unnecessary root kustomization for moc

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,6 +1,0 @@
-# TODO: Remove this file once the path on moc-cnv-sandbox repo is updated to overlays/moc for agocd app-of-apps application
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: argocd
-resources:
-- overlays/moc


### PR DESCRIPTION
The moc app-of-apps is not pointing to the sub moc folder, so we don't need this root kustomization anymore (see [here](https://github.com/open-infrastructure-labs/moc-cnv-sandbox/blob/master/manifests/argocd/overlays/prod/applications/operate-first-app-of-apps.yaml#L11))