### PR TITLE
opf-ci-prow component is deployed on moc cluster only

### DIFF
--- a/overlays/moc/operate-first/kustomization.yaml
+++ b/overlays/moc/operate-first/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base/operate-first
+  - ci-prow.yaml
 patchesStrategicMerge:
   - jupyterhub.yaml
   - monitoring.yaml
@@ -11,4 +12,3 @@ patchesStrategicMerge:
   - datacatalog.yaml
   - kafka.yaml
   - observatorium.yaml
-  - ci-prow.yaml


### PR DESCRIPTION
opf-ci-prow component is deployed on moc cluster only
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: #34 


As opf-ci-prow is just part of moc cluster, adding it to the **patchesStrategicMerge** causes issues:
```
rpc error: code = Unknown desc = `kustomize build /tmp/https:__github.com_operate-first_argocd-apps/overlays/moc --enable_alpha_plugins` failed exit status 1: Error: accumulating resources: accumulateFile "accumulating resources from 'operate-first': '/tmp/https:__github.com_operate-first_argocd-apps/overlays/moc/operate-first' must resolve to a file", accumulateDirector: "recursed accumulation of path '/tmp/https:__github.com_operate-first_argocd-apps/overlays/moc/operate-first': no matches for OriginalId argoproj.io_v1alpha1_Application|~X|ci-prow-cluster-admin; no matches for CurrentId argoproj.io_v1alpha1_Application|~X|ci-prow-cluster-admin; failed to find unique target for patch argoproj.io_v1alpha1_Application|ci-prow-cluster-admin"
```