### PR TITLE
Fix cluster name in cluster-management group

### DIFF
--- a/base/cluster-management/cluster-resources.yaml
+++ b/base/cluster-management/cluster-resources.yaml
@@ -10,7 +10,7 @@ spec:
     targetRevision: HEAD
     # path: implement in an overlay
   destination:
-    server: in-cluster
+    name: in-cluster
     namespace: argocd
   syncPolicy:
     syncOptions:


### PR DESCRIPTION
The name is the human friendly cluster reference, "server" is the actual uri for the server.