### PR TITLE
fix the path used for ignoring difference of image

### DIFF
--- a/overlays/moc/thoth/prod/prod-thoth-sefkhet-abwy.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-sefkhet-abwy.yaml
@@ -23,9 +23,9 @@ spec:
       kind: CronJob
       name: new-label-normalizer-aicoe
       jsonPointers:
-        - /spec/template/spec/containers/0/image
+        - /spec/jobTemplate/spec/template/spec/containers/0/image
     - group: batch
       kind: CronJob
       name: new-label-normalizer-thoth-station
       jsonPointers:
-        - /spec/template/spec/containers/0/image
+        - /spec/jobTemplate/spec/template/spec/containers/0/image


### PR DESCRIPTION
fix the path used for ignoring difference of image
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


missed to include the jobtemplate for cronjob.