### PR TITLE
ignore difference of image for ghproxy deployment

### DIFF
--- a/overlays/moc/thoth/prod/prod-thoth-sefkhet-abwy.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-sefkhet-abwy.yaml
@@ -29,3 +29,8 @@ spec:
       name: new-label-normalizer-thoth-station
       jsonPointers:
         - /spec/jobTemplate/spec/template/spec/containers/0/image
+    - group: apps
+      kind: Deployment
+      name: ghproxy
+      jsonPointers:
+        - /spec/template/spec/containers/0/image


### PR DESCRIPTION
ignore difference of image for ghproxy deployment
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/thoth-station/thoth-application/issues/800