### PR TITLE
feat: Create a standalone ClusterLogging app within operate-first project

### DIFF
--- a/base/operate-first/cluster-logging.yaml
+++ b/base/operate-first/cluster-logging.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-logging
+spec:
+  project: operate-first
+  source:
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+    # path: implement in an overlay
+  destination:
+    name: in-cluster
+    namespace: openshift-logging

--- a/base/operate-first/kustomization.yaml
+++ b/base/operate-first/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - dashboard.yaml
   - kafka.yaml
   - observatorium.yaml
+  - cluster-logging.yaml

--- a/overlays/crc/operate-first/cluster-logging.yaml
+++ b/overlays/crc/operate-first/cluster-logging.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-logging
+spec:
+  source:
+    path: cluster-logging/overlays/crc/

--- a/overlays/crc/operate-first/kustomization.yaml
+++ b/overlays/crc/operate-first/kustomization.yaml
@@ -12,3 +12,4 @@ patchesStrategicMerge:
   - dashboard.yaml
   - kafka.yaml
   - observatorium.yaml
+  - cluster-logging.yaml

--- a/overlays/moc/operate-first/cluster-logging.yaml
+++ b/overlays/moc/operate-first/cluster-logging.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-logging
+spec:
+  source:
+    path: cluster-logging/overlays/moc/
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/overlays/moc/operate-first/kustomization.yaml
+++ b/overlays/moc/operate-first/kustomization.yaml
@@ -12,3 +12,4 @@ patchesStrategicMerge:
   - datacatalog.yaml
   - kafka.yaml
   - observatorium.yaml
+  - cluster-logging.yaml

--- a/overlays/quicklab/operate-first/cluster-logging.yaml
+++ b/overlays/quicklab/operate-first/cluster-logging.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-logging
+spec:
+  source:
+    path: cluster-logging/overlays/quicklab/

--- a/overlays/quicklab/operate-first/kustomization.yaml
+++ b/overlays/quicklab/operate-first/kustomization.yaml
@@ -12,3 +12,4 @@ patchesStrategicMerge:
   - dashboard.yaml
   - kafka.yaml
   - observatorium.yaml
+  - cluster-logging.yaml


### PR DESCRIPTION
Resolves: https://github.com/operate-first/apps/issues/174

Depends on: https://github.com/operate-first/apps/pull/173
Merge together with: https://github.com/operate-first/continuous-deployment/pull/97