### PR TITLE
Ignore cluster auth generated values.

### DIFF
--- a/overlays/moc/cluster-management/cluster-resources.yaml
+++ b/overlays/moc/cluster-management/cluster-resources.yaml
@@ -6,3 +6,14 @@ metadata:
 spec:
   source:
     path: cluster-scope/overlays/moc/
+  ignoreDifferences:
+    - group: imageregistry.operator.openshift.io
+      kind: Config
+      name: cluster
+      version: v1
+      jsonPointers:
+        - /spec/defaultRoute
+        - /spec/httpSecret
+        - /spec/proxy
+        - /spec/requests
+        - /spec/rolloutStrategy


### PR DESCRIPTION
These values are not ignored by ArgoCD by default, which results in argocd fighting with the auth operator to remove these values. 