### PR TITLE
Changed moc from in-cluster to server name

### DIFF
--- a/overlays/moc/cluster-management/argocd-projects.yaml
+++ b/overlays/moc/cluster-management/argocd-projects.yaml
@@ -4,8 +4,8 @@ metadata:
   name: argocd-projects
 spec:
   destination:
+    name: moc-cnv
     namespace: argocd
-    name: in-cluster
   project: default
   source:
     path: manifests/overlays/moc-cnv/projects

--- a/overlays/moc/cluster-management/ceph.yaml
+++ b/overlays/moc/cluster-management/ceph.yaml
@@ -4,5 +4,7 @@ kind: Application
 metadata:
   name: ceph
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: ceph/overlays/moc/

--- a/overlays/moc/cluster-management/cluster-resources.yaml
+++ b/overlays/moc/cluster-management/cluster-resources.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: cluster-resources
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: cluster-scope/overlays/moc/
   ignoreDifferences:

--- a/overlays/moc/cluster-management/kubevirt-hyperconverged.yaml
+++ b/overlays/moc/cluster-management/kubevirt-hyperconverged.yaml
@@ -4,5 +4,7 @@ kind: Application
 metadata:
   name: kubevirt-hyperconverged
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: kubevirt-hyperconverged/overlays/moc/

--- a/overlays/moc/cluster-management/local-storage.yaml
+++ b/overlays/moc/cluster-management/local-storage.yaml
@@ -4,5 +4,7 @@ kind: Application
 metadata:
   name: local-storage
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: local-storage/overlays/moc/

--- a/overlays/moc/data-science/black-flake.yml
+++ b/overlays/moc/data-science/black-flake.yml
@@ -4,8 +4,8 @@ metadata:
   name: black-flake
 spec:
   destination:
+    name: moc-cnv
     namespace: ds-black-flake
-    name: in-cluster
   project: data-science
   source:
     repoURL: https://github.com/aicoe-aiops/ocp-ci-analysis.git

--- a/overlays/moc/data-science/kustomization.yaml
+++ b/overlays/moc/data-science/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
   - ../../../base/data-science
   - black-flake.yml
+
+patchesStrategicMerge:
+  - mailing-list-analysis-toolkit.yaml

--- a/overlays/moc/data-science/mailing-list-analysis-toolkit.yaml
+++ b/overlays/moc/data-science/mailing-list-analysis-toolkit.yaml
@@ -1,9 +1,8 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: opf-superset
+  name: mailing-list-analysis-toolkit
 spec:
   destination:
     name: moc-cnv
-  source:
-    path: odh/overlays/moc/superset

--- a/overlays/moc/operate-first/argo.yaml
+++ b/overlays/moc/operate-first/argo.yaml
@@ -3,5 +3,7 @@ kind: Application
 metadata:
   name: opf-argo
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: odh/overlays/moc/argo

--- a/overlays/moc/operate-first/ci-prow.yaml
+++ b/overlays/moc/operate-first/ci-prow.yaml
@@ -10,8 +10,8 @@ spec:
     repoURL: "https://github.com/thoth-station/thoth-application.git"
     targetRevision: master
   destination:
+    name: moc-cnv
     namespace: opf-ci-prow
-    server: "https://kubernetes.default.svc"
   syncPolicy:
     automated:
       prune: true

--- a/overlays/moc/operate-first/cluster-logging.yaml
+++ b/overlays/moc/operate-first/cluster-logging.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: cluster-logging
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: cluster-logging/overlays/moc/
   syncPolicy:

--- a/overlays/moc/operate-first/dashboard.yaml
+++ b/overlays/moc/operate-first/dashboard.yaml
@@ -3,5 +3,7 @@ kind: Application
 metadata:
   name: opf-dashboard
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: odh/overlays/moc/dashboard

--- a/overlays/moc/operate-first/datacatalog.yaml
+++ b/overlays/moc/operate-first/datacatalog.yaml
@@ -3,5 +3,7 @@ kind: Application
 metadata:
   name: opf-datacatalog
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: odh/overlays/moc/datacatalog

--- a/overlays/moc/operate-first/jupyterhub.yaml
+++ b/overlays/moc/operate-first/jupyterhub.yaml
@@ -3,5 +3,7 @@ kind: Application
 metadata:
   name: opf-jupyterhub
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: odh/overlays/moc/jupyterhub

--- a/overlays/moc/operate-first/kafka.yaml
+++ b/overlays/moc/operate-first/kafka.yaml
@@ -3,5 +3,7 @@ kind: Application
 metadata:
   name: opf-kafka
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: odh/overlays/moc/kafka

--- a/overlays/moc/operate-first/monitoring.yaml
+++ b/overlays/moc/operate-first/monitoring.yaml
@@ -3,5 +3,7 @@ kind: Application
 metadata:
   name: opf-monitoring
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: odh/overlays/moc/monitoring

--- a/overlays/moc/operate-first/observatorium.yaml
+++ b/overlays/moc/operate-first/observatorium.yaml
@@ -3,5 +3,7 @@ kind: Application
 metadata:
   name: opf-observatorium
 spec:
+  destination:
+    name: moc-cnv
   source:
     path: observatorium/overlays/moc/

--- a/overlays/moc/operate-first/prod-aicoe-ci.yaml
+++ b/overlays/moc/operate-first/prod-aicoe-ci.yaml
@@ -10,7 +10,7 @@ spec:
     path: manifests/overlays/moc
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: opf-ci-pipelines
   syncPolicy:
     automated: {}

--- a/overlays/moc/thoth/prod/core-backend.yaml
+++ b/overlays/moc/thoth/prod/core-backend.yaml
@@ -11,7 +11,7 @@ spec:
     targetRevision: master
   destination:
     namespace: thoth-backend-prod
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
   syncPolicy:
     automated:
       selfHeal: true

--- a/overlays/moc/thoth/prod/core-frontend.yaml
+++ b/overlays/moc/thoth/prod/core-frontend.yaml
@@ -11,7 +11,7 @@ spec:
     targetRevision: master
   destination:
     namespace: thoth-frontend-prod
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
   syncPolicy:
     automated:
       selfHeal: true

--- a/overlays/moc/thoth/prod/core-graph.yaml
+++ b/overlays/moc/thoth/prod/core-graph.yaml
@@ -11,7 +11,7 @@ spec:
     targetRevision: master
   destination:
     namespace: thoth-graph-prod
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
   syncPolicy:
     automated:
       selfHeal: true

--- a/overlays/moc/thoth/prod/core-infra.yaml
+++ b/overlays/moc/thoth/prod/core-infra.yaml
@@ -11,7 +11,7 @@ spec:
     targetRevision: master
   destination:
     namespace: thoth-infra-prod
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
   syncPolicy:
     automated:
       selfHeal: true

--- a/overlays/moc/thoth/prod/core-middletier.yaml
+++ b/overlays/moc/thoth/prod/core-middletier.yaml
@@ -11,7 +11,7 @@ spec:
     targetRevision: master
   destination:
     namespace: thoth-middletier-prod
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
   syncPolicy:
     automated:
       prune: true

--- a/overlays/moc/thoth/prod/prod-thoth-advise-reporter.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-advise-reporter.yaml
@@ -10,7 +10,7 @@ spec:
     path: advise-reporter/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-infra-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-adviser.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-adviser.yaml
@@ -10,7 +10,7 @@ spec:
     path: adviser/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-backend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-amun-api.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-amun-api.yaml
@@ -10,7 +10,7 @@ spec:
     path: amun/overlays/cnv-prod/amun-api
     targetRevision: HEAD
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-amun-api-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-amun-inspection.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-amun-inspection.yaml
@@ -10,7 +10,7 @@ spec:
     path: amun/overlays/cnv-prod/amun-inspection
     targetRevision: HEAD
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-amun-inspection-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-bot-sefkhet-abwy-chatbot.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-bot-sefkhet-abwy-chatbot.yaml
@@ -10,7 +10,7 @@ spec:
     path: sefkhet-abwy-chatbot/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-bots-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-chat-notification.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-chat-notification.yaml
@@ -10,7 +10,7 @@ spec:
     path: chat-notification/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-infra-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-cve-update.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-cve-update.yaml
@@ -10,7 +10,7 @@ spec:
     path: cve-update/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-frontend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-elyra-aidevsecops-tutorial.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-elyra-aidevsecops-tutorial.yaml
@@ -10,7 +10,7 @@ spec:
     path: manifests/overlays/test
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-deployment-examples
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-graph-backup.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-graph-backup.yaml
@@ -10,7 +10,7 @@ spec:
     path: graph-backup-job/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-frontend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-graph-refresh.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-graph-refresh.yaml
@@ -10,7 +10,7 @@ spec:
     path: graph-refresh/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-frontend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-graph-sync-backend.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-graph-sync-backend.yaml
@@ -10,7 +10,7 @@ spec:
     path: graph-sync/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-backend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-graph-sync-middletier.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-graph-sync-middletier.yaml
@@ -10,7 +10,7 @@ spec:
     path: graph-sync/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-middletier-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-investigator.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-investigator.yaml
@@ -10,7 +10,7 @@ spec:
     path: investigator/overlays/cnv-prod
     targetRevision: HEAD
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-infra-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-kebechet.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-kebechet.yaml
@@ -10,7 +10,7 @@ spec:
     path: kebechet/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-backend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-management-api.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-management-api.yaml
@@ -10,7 +10,7 @@ spec:
     path: management-api/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-frontend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-metrics-exporter.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-metrics-exporter.yaml
@@ -10,7 +10,7 @@ spec:
     path: metrics-exporter/overlays/cnv-prod
     targetRevision: HEAD
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-infra-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-mi.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-mi.yaml
@@ -10,7 +10,7 @@ spec:
     path: mi-scheduler/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-middletier-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-package-extract.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-package-extract.yaml
@@ -10,7 +10,7 @@ spec:
     path: package-extract/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-middletier-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-package-releases.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-package-releases.yaml
@@ -10,7 +10,7 @@ spec:
     path: package-releases/overlays/cnv-prod
     targetRevision: HEAD
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-frontend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-package-update.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-package-update.yaml
@@ -10,7 +10,7 @@ spec:
     path: package-update/overlays/cnv-prod
     targetRevision: HEAD
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-frontend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-qeb-hwt.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-qeb-hwt.yaml
@@ -10,7 +10,7 @@ spec:
     path: qeb-hwt-github-app/overlays/cnv-prod
     targetRevision: HEAD
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-frontend-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-revsolver.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-revsolver.yaml
@@ -10,7 +10,7 @@ spec:
     path: revsolver/overlays/cnv-prod
     targetRevision: HEAD
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-middletier-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-security-indicators.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-security-indicators.yaml
@@ -10,7 +10,7 @@ spec:
     path: security-indicators/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-middletier-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-sefkhet-abwy.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-sefkhet-abwy.yaml
@@ -10,7 +10,7 @@ spec:
     path: sefkhet-abwy/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-bots-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-slo-reporter.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-slo-reporter.yaml
@@ -10,7 +10,7 @@ spec:
     path: slo-reporter/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-infra-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-solver.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-solver.yaml
@@ -10,7 +10,7 @@ spec:
     path: solver/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-middletier-prod
   syncPolicy:
     automated:

--- a/overlays/moc/thoth/prod/prod-thoth-user-api.yaml
+++ b/overlays/moc/thoth/prod/prod-thoth-user-api.yaml
@@ -10,7 +10,7 @@ spec:
     path: user-api/overlays/cnv-prod
     targetRevision: master
   destination:
-    server: "https://kubernetes.default.svc"
+    name: moc-cnv
     namespace: thoth-frontend-prod
   syncPolicy:
     automated:


### PR DESCRIPTION
Related to [migration](https://github.com/operate-first/SRE/issues/83)
Requires this [pr to be merged](https://github.com/operate-first/continuous-deployment/pull/108), with the cluster specs deployed.

Before PR merge ensure: 
- ArgoCD has been deployed on moc-infra
- moc-infra has the app-of-apps argocd application pointed to this repo (with auto sync off)
- moc-infra has the argocd cluster added named "moc-cnv" and is showing green

With the above done, the merger of this PR should not indicate any change (which is a good thing) to current deployments. With this PR merged, we should be able to migrate apps by simply moving the apps to another overlay `moc-infra` and updating the destination accordingly. 
