### PR TITLE
Fix server destinations for workshop and argocd proj

### DIFF
--- a/overlays/moc-infra/cluster-management/argocd-projects.yaml
+++ b/overlays/moc-infra/cluster-management/argocd-projects.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argocd-projects
 spec:
   destination:
-    name: moc-cnv
+    name: moc-infra
     namespace: argocd
   project: default
   source:

--- a/overlays/moc-infra/workshops/app-of-apps.yaml
+++ b/overlays/moc-infra/workshops/app-of-apps.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ml-prague-app-of-apps
+spec:
+  destination:
+    name: moc-infra

--- a/overlays/moc-infra/workshops/kustomization.yaml
+++ b/overlays/moc-infra/workshops/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base/workshops
+patchesStrategicMerge:
+  - app-of-apps.yaml


### PR DESCRIPTION
The destinations for these apps need to be updated to be `moc-infra` as these apps deploy argocd resources.