### PR TITLE
Switch workshop cluster to named in-cluster, for patching.

### DIFF
--- a/base/workshops/app-of-apps.yaml
+++ b/base/workshops/app-of-apps.yaml
@@ -11,7 +11,7 @@ spec:
     targetRevision: HEAD
   destination:
     namespace: argocd
-    server: "https://kubernetes.default.svc"
+    name: in-cluster
   syncPolicy:
     automated:
       selfHeal: true


### PR DESCRIPTION
Currently the patch will only add the named cluster, which will co-exist with the "destination.server" field, and these 2 cannot co-exist. 