### PR TITLE
Remove version from ignoredifferences for cluster resources.

### DIFF
--- a/overlays/moc-cnv/cluster-management/cluster-resources.yaml
+++ b/overlays/moc-cnv/cluster-management/cluster-resources.yaml
@@ -12,7 +12,6 @@ spec:
     - group: imageregistry.operator.openshift.io
       kind: Config
       name: cluster
-      version: v1
       jsonPointers:
         - /spec/defaultRoute
         - /spec/httpSecret


### PR DESCRIPTION
So `version` is not a thing [see here](https://github.com/argoproj/argo-cd/blob/master/manifests/crds/application-crd.yaml#L355). Heh.