### PR TITLE
ignore image difference for ci prow cronjob

### DIFF
--- a/overlays/moc-cnv/operate-first/ci-prow.yaml
+++ b/overlays/moc-cnv/operate-first/ci-prow.yaml
@@ -23,3 +23,7 @@ spec:
       kind: Deployment
       jsonPointers:
         - /spec/template/spec/containers/0/image
+    - group: batch
+      kind: CronJob
+      jsonPointers:
+        - /spec/jobTemplate/spec/template/spec/containers/0/image


### PR DESCRIPTION
ignore image difference for ci prow cronjob
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>