### PR TITLE
Add kfdef app.

### DIFF
--- a/envs/moc/zero/operate-first/kfdefs.yaml
+++ b/envs/moc/zero/operate-first/kfdefs.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opf-kfdefs
+spec:
+  destination:
+    name: zero
+    namespace: opendatahub
+  project: operate-first
+  source:
+    path: kfdefs/overlays/moc/zero
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD

--- a/envs/moc/zero/operate-first/kustomization.yaml
+++ b/envs/moc/zero/operate-first/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - datacatalog.yaml
   - jupyterhub.yaml
   - kafka.yaml
+  - kfdefs.yaml
   - monitoring.yaml
   - observatorium.yaml
   - observatorium-operator.yaml


### PR DESCRIPTION
Depends on: https://github.com/operate-first/apps/pull/401#event-4476751824

So the `opendatahub` namespace doesn't exist, but none of the resources are being deployed there, rather they are deployed to namespaces designated by their respective kustomization.yaml files. So I'm not exactly sure if ArgoCD will complain, but let's see. I could put `default` but, I'd rather avoid that. We could always just make an empty namespace if we needed to called `opendatahub` for this purpose I suppose. 