### PR TITLE
Move kfdef app to be under cluster-management proj.

### DIFF
--- a/envs/moc/zero/cluster-management/kfdefs.yaml
+++ b/envs/moc/zero/cluster-management/kfdefs.yaml
@@ -2,12 +2,12 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: opf-kfdefs
+  name: kfdefs
 spec:
   destination:
     name: zero
     namespace: opendatahub
-  project: operate-first
+  project: cluster-management
   source:
     path: kfdefs/overlays/moc/zero
     repoURL: https://github.com/operate-first/apps.git

--- a/envs/moc/zero/cluster-management/kustomization.yaml
+++ b/envs/moc/zero/cluster-management/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - alertreceiver.yaml
   - ceph.yaml
   - cluster-resources.yaml
+  - kfdefs.yaml
   - kubevirt-hyperconverged.yaml
   - local-storage.yaml

--- a/envs/moc/zero/operate-first/kustomization.yaml
+++ b/envs/moc/zero/operate-first/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - datacatalog.yaml
   - jupyterhub.yaml
   - kafka.yaml
-  - kfdefs.yaml
   - monitoring.yaml
   - observatorium.yaml
   - observatorium-operator.yaml


### PR DESCRIPTION
Moving Kfdef app to be under the cluster-management project. The reason is that the operate-first app doesn't have the permissions to deploy to any arbitrary namespace (they must be prefixed with opf-* with _some_ exceptions), but users may want a kfdef deployed in any namespace prefixed via their team name/abbreviations. 

I think you can also make a case that kfdef is a cluster-management resource so it makes sense to put it under this project. 