### PR TITLE
Change default cluster-resources ns to guaranteed existing ns.

### DIFF
--- a/envs/moc/curator/cluster-management/cluster-resources.yaml
+++ b/envs/moc/curator/cluster-management/cluster-resources.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   destination:
     name: curator
-    namespace: argocd
+    namespace: open-cluster-management-agent
   ignoreDifferences:
     - group: imageregistry.operator.openshift.io
       jsonPointers:

--- a/envs/moc/infra/cluster-management/cluster-resources.yaml
+++ b/envs/moc/infra/cluster-management/cluster-resources.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   destination:
     name: moc-infra
-    namespace: argocd
+    namespace: open-cluster-management-agent
   project: cluster-management
   source:
     path: cluster-scope/overlays/moc/infra

--- a/envs/moc/zero/cluster-management/cluster-resources.yaml
+++ b/envs/moc/zero/cluster-management/cluster-resources.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   destination:
     name: zero
-    namespace: argocd
+    namespace: open-cluster-management-agent
   ignoreDifferences:
   - group: imageregistry.operator.openshift.io
     jsonPointers:


### PR DESCRIPTION
We cannot guarantee that the namespace `argocd` will be there from the onset, it will require manual creation during cluster reset. Instead it would be better to use a namespace that is guaranteed to exist, so we are opting to use `open-cluster-management-agent`, created by ACM. No actual resources should be deployed to this namespace as this app deploys mostly cluster resources, and wherever it deploys namespace-scoped resources, the namespaces are manually specific within the apps repo itself.