### PR TITLE
Relocate per-cluster app-of-apps to argocd-apps

### DIFF
--- a/app-of-apps/app-of-apps-curator.yaml
+++ b/app-of-apps/app-of-apps-curator.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opf-app-of-apps-curator
+spec:
+  destination:
+    namespace: argocd
+    name: moc-infra
+  project: operate-first
+  source:
+    path: envs/moc/curator
+    repoURL: https://github.com/operate-first/argocd-apps.git
+    targetRevision: HEAD

--- a/app-of-apps/app-of-apps-infra.yaml
+++ b/app-of-apps/app-of-apps-infra.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opf-app-of-apps-infra
+spec:
+  destination:
+    namespace: argocd
+    name: moc-infra
+  project: operate-first
+  source:
+    path: envs/moc/infra
+    repoURL: https://github.com/operate-first/argocd-apps.git
+    targetRevision: HEAD

--- a/app-of-apps/app-of-apps-zero.yaml
+++ b/app-of-apps/app-of-apps-zero.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opf-app-of-apps-zero
+spec:
+  destination:
+    namespace: argocd
+    name: moc-infra
+  project: operate-first
+  source:
+    path: envs/moc/zero
+    repoURL: https://github.com/operate-first/argocd-apps.git
+    targetRevision: HEAD

--- a/app-of-apps/kustomization.yaml
+++ b/app-of-apps/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+resources:
+  - app-of-apps-curator.yaml
+  - app-of-apps-infra.yaml
+  - app-of-apps-zero.yaml


### PR DESCRIPTION
Furthers #115 -- will also require us to have a complimentary PR to reference these from the argocd manifest repo: https://github.com/operate-first/continuous-deployment/pull/137