### PR TITLE
Turn off autosync for ml app of apps.

### DIFF
--- a/envs/moc/infra/workshops/app-of-apps.yaml
+++ b/envs/moc/infra/workshops/app-of-apps.yaml
@@ -11,9 +11,3 @@ spec:
     path: ml-prague-2021
     repoURL: https://github.com/operate-first/workshop-apps.git
     targetRevision: HEAD
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-    - Validate=false


### PR DESCRIPTION
I manually deleted the apps that were created by this application, since they do not have an active cluster they were stuck in a continuous unknown state, whereby the child applications were continuously hogging sync/refresh queue spots which in turn was slowing down argocd for the other applications. 

I would like to turn off auto sync here, as I have manually turned it off in live and deleted the child apps. This isn't really a proper fix to #108, because we should look for a permanent setting for these apps, but for now it's enough to stop this app from deploying the child apps with no target clusters.