### PR TITLE
fix: Apicurio app to use default branch

### DIFF
--- a/envs/moc/zero/apicurio/registry.yml
+++ b/envs/moc/zero/apicurio/registry.yml
@@ -10,7 +10,7 @@ spec:
   source:
     path: manifests
     repoURL: https://github.com/paoloantinori/apicurio-operate-first
-    targetRevision: master
+    targetRevision: HEAD
   syncPolicy:
     syncOptions:
     - Validate=false


### PR DESCRIPTION
There's no `master` branch in https://github.com/paoloantinori/apicurio-operate-first it uses `main` instead.

Let's turn this app to use the default branch via the `HEAD` reference.

Fixes: https://github.com/operate-first/argocd-apps/pull/129