### PR TITLE
updated graph-backup to graph namespace

### DIFF
--- a/envs/moc/zero/thoth/prod/prod-thoth-graph-backup.yaml
+++ b/envs/moc/zero/thoth/prod/prod-thoth-graph-backup.yaml
@@ -11,7 +11,7 @@ spec:
     targetRevision: master
   destination:
     name: zero
-    namespace: thoth-frontend-prod
+    namespace: thoth-graph-prod
   syncPolicy:
     automated:
       selfHeal: true


### PR DESCRIPTION
Migrated graph-backup job to thoth-graph-prod namespace. in response to thoth-station/thoth-application/issues/1166.
Fixes: thoth-station/thoth-application/issues/1166