### PR TITLE
change the deployment namespace for thoth task graph

### DIFF
--- a/envs/moc/zero/thoth/prod/prod-thoth-purge-job.yaml
+++ b/envs/moc/zero/thoth/prod/prod-thoth-purge-job.yaml
@@ -11,7 +11,7 @@ spec:
     targetRevision: master
   destination:
     name: zero
-    namespace: thoth-middletier-prod
+    namespace: thoth-backend-prod
   syncPolicy:
     automated:
       selfHeal: true


### PR DESCRIPTION
change the deployment namespace for thoth task graph
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


moving to another namespace for better utilization.