### PR TITLE
feat: Deploy Keycloak 

### DIFF
--- a/envs/moc/infra/cluster-management/keycloak.yaml
+++ b/envs/moc/infra/cluster-management/keycloak.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keycloak
+spec:
+  destination:
+    name: moc-infra
+    namespace: keycloak
+  project: cluster-management
+  source:
+    path: keycloak/overlays/moc/infra
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/envs/moc/infra/cluster-management/kustomization.yaml
+++ b/envs/moc/infra/cluster-management/kustomization.yaml
@@ -3,7 +3,8 @@ kind: Kustomization
 resources:
   - acm.yaml
   - alertreceiver.yaml
-  - argocd.yaml
   - argocd-projects.yaml
+  - argocd.yaml
   - cluster-resources.yaml
+  - keycloak.yaml
   - kubevirt-hyperconverged.yaml

--- a/envs/moc/zero/cluster-management/dex.yaml
+++ b/envs/moc/zero/cluster-management/dex.yaml
@@ -2,14 +2,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: opf-auth
+  name: dex
 spec:
   destination:
     name: zero
-    namespace: opf-auth
-  project: operate-first
+    namespace: dex
+  project: cluster-management
   source:
-    path: auth/overlays/moc/zero
+    path: dex/overlays/moc/zero
     repoURL: https://github.com/operate-first/apps.git
     targetRevision: HEAD
   syncPolicy:
@@ -17,4 +17,4 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-    - Validate=false
+      - Validate=false

--- a/envs/moc/zero/cluster-management/kustomization.yaml
+++ b/envs/moc/zero/cluster-management/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - alertreceiver.yaml
   - ceph.yaml
   - cluster-resources.yaml
+  - dex.yaml
   - kfdefs.yaml
   - knative.yaml
   - kubevirt-hyperconverged.yaml

--- a/envs/moc/zero/operate-first/kustomization.yaml
+++ b/envs/moc/zero/operate-first/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - acme-operator.yaml
-  - auth.yaml
   - ci-prow-test-pods.yaml
   - ci-prow.yaml
   - cluster-logging.yaml


### PR DESCRIPTION
Requires: https://github.com/operate-first/apps/pull/838
Part of: https://github.com/operate-first/apps/issues/789

- [x] Move Dex from `opf-auth` to `dex` namespace
- [x] Deploy Keycloak into `keycloak` namespace