### PR TITLE
Create mocops appproject

### DIFF
--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -4,11 +4,12 @@ resources:
   - apicurio-registry.yaml
   - b4mad.yaml
   - cluster-management.yaml
-  - operate-first.yaml
   - data-science.yaml
-  - thoth.yaml
-  - rekor.yaml
+  - global_project.yaml
   - lab-cicd.yaml
   - mesh-for-data.yaml
-  - global_project.yaml
+  - mocops.yaml
+  - operate-first.yaml
+  - rekor.yaml
+  - thoth.yaml
   - workshops.yaml

--- a/projects/mocops.yaml
+++ b/projects/mocops.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: mocops
+spec:
+  destinations:
+  - namespace: '*'
+    server: 'https://api.ocp-prod.massopen.cloud:6443'
+  sourceRepos:
+  - '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'


### PR DESCRIPTION
This project will be used by moc ops staff deploying to the moc
ocp-prod cluster.
