### PR TITLE
feat: move ci-prow to smaug

### DIFF
--- a/envs/moc/smaug/operate-first/ci-prow-test-pods.yaml
+++ b/envs/moc/smaug/operate-first/ci-prow-test-pods.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ci-prow-prod-test-pods
+spec:
+  destination:
+    name: smaug
+    namespace: opf-ci-test-pods
+  ignoreDifferences:
+    - group: apps
+      jsonPointers:
+        - /spec/template/spec/containers/0/image
+      kind: Deployment
+    - group: batch
+      jsonPointers:
+        - /spec/jobTemplate/spec/template/spec/containers/0/image
+      kind: CronJob
+  project: operate-first
+  source:
+    path: prow/overlays/cnv-prod-test-pods
+    repoURL: https://github.com/thoth-station/thoth-application.git
+    targetRevision: master
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/envs/moc/smaug/operate-first/ci-prow.yaml
+++ b/envs/moc/smaug/operate-first/ci-prow.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ci-prow-prod
+spec:
+  destination:
+    name: smaug
+    namespace: opf-ci-prow
+  ignoreDifferences:
+  - group: apps
+    jsonPointers:
+    - /spec/template/spec/containers/0/image
+    kind: Deployment
+  - group: batch
+    jsonPointers:
+    - /spec/jobTemplate/spec/template/spec/containers/0/image
+    kind: CronJob
+  project: operate-first
+  source:
+    path: prow/overlays/smaug
+    repoURL: https://github.com/thoth-station/thoth-application.git
+    targetRevision: master
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/envs/moc/smaug/operate-first/kustomization.yaml
+++ b/envs/moc/smaug/operate-first/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - acme-operator.yaml
+  - ci-prow-test-pods.yaml
+  - ci-prow.yaml


### PR DESCRIPTION
Moving ci-prow from zero to smaug, because they are not working currently on zero.
Related: https://github.com/operate-first/apps/pull/953