### PR TITLE
Revert "fix: ApplicationSets should be allowed in operate first ArgoCD project"

### DIFF
--- a/projects/operate-first.yaml
+++ b/projects/operate-first.yaml
@@ -52,8 +52,6 @@ spec:
         - operate-first
   namespaceResourceWhitelist:
     - group: argoproj.io
-      kind: ApplicationSet
-    - group: argoproj.io
       kind: Application
     - group: logging.openshift.io
       kind: ClusterLogging


### PR DESCRIPTION
Reverts operate-first/argocd-apps#189

We have old ArgoCD, there are no ApplicationSets resources. :facepalm: 