### PR TITLE
fix: Workshop apps via directory and on devconfus2021 cluster

### DIFF
--- a/app-of-apps/workshops-app-of-apps.yaml
+++ b/app-of-apps/workshops-app-of-apps.yaml
@@ -11,3 +11,11 @@ spec:
     path: apps
     repoURL: https://github.com/operate-first/workshop-apps.git
     targetRevision: HEAD
+    directory:
+      recurse: true
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/projects/workshops.yaml
+++ b/projects/workshops.yaml
@@ -6,12 +6,8 @@ metadata:
     project-template: global
 spec:
   destinations:
-    - namespace: "ws-*"
-      server: 'https://api.zero.massopen.cloud:6443'
-    - namespace: "ws-*"
-      server: 'https://api.cluster-9566.9566.example.opentlc.com:6443'
-    - namespace: "workshop-*"
-      server: 'https://api.cluster-9566.9566.example.opentlc.com:6443'
+    - namespace: "elyra-aidevsecops-tutorial"
+      server: "https://api.devconfus2021.aws.operate-first.cloud:6443"
   sourceRepos:
     - "*"
   roles:


### PR DESCRIPTION
Should allow workshop apps to be deployed via ArgoCD to the devconfus2021 cluster - permits the elyra namespace only and uses recursive directory strategy instead of kustomize for the app of apps structure