### PR TITLE
Prune the ci prow from the zero cluster

### DIFF
--- a/envs/moc/zero/operate-first/kustomization.yaml
+++ b/envs/moc/zero/operate-first/kustomization.yaml
@@ -2,8 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - acme-operator.yaml
-  - ci-prow-test-pods.yaml
-  - ci-prow.yaml
   - cluster-logging.yaml
   - jh-idle-culler.yaml
   - kubeflow.yaml


### PR DESCRIPTION
Prune the ci prow from the zero cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


As the ci -prow is now functional in the **smaug** cluster, let decommission it from **zero**
Haven't removed the application manifests, itself for just future usage if needed.