### PR TITLE
Prune the thoth-station Test from the zero cluster

### DIFF
--- a/envs/moc/zero/thoth/test/kustomization.yaml
+++ b/envs/moc/zero/thoth/test/kustomization.yaml
@@ -1,22 +1,3 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- core-test.yaml
-- test-thoth-advise-reporter.yaml
-- test-thoth-adviser.yaml
-- test-thoth-chat-notification.yaml
-- test-thoth-cve-update.yaml
-- test-thoth-graph-backup.yaml
-- test-thoth-graph-refresh.yaml
-- test-thoth-graph-sync.yaml
-- test-thoth-investigator.yaml
-- test-thoth-kebechet.yaml
-- test-thoth-management-api.yaml
-- test-thoth-metrics-exporter.yaml
-- test-thoth-mi.yaml
-- test-thoth-package-extract.yaml
-- test-thoth-package-releases.yaml
-- test-thoth-package-update.yaml
-- test-thoth-security-indicators.yaml
-- test-thoth-solver.yaml
-- test-thoth-user-api.yaml
+resources: []


### PR DESCRIPTION
Prune the thoth-station Test from the zero cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


The manifest is not pruned so that we can relocate them to another cluster.