### PR TITLE
Permit mocops project access to CCI-MOC repos via ssh

### DIFF
--- a/projects/mocops.yaml
+++ b/projects/mocops.yaml
@@ -8,6 +8,7 @@ spec:
     server: 'https://api.ocp-prod.massopen.cloud:6443'
   sourceRepos:
     - 'https://github.com/CCI-MOC/*'
+    - 'git@github.com:CCI-MOC/*'
   clusterResourceWhitelist:
   - group: '*'
     kind: '*'


### PR DESCRIPTION
We're using a private repository as a temporary solution to
distributing entitlements to our cluster nodes. We need to permit the
mocops project to access ssh repository urls.
