### PR TITLE
feature/allow moc ssh repo

### DIFF
--- a/projects/mocops.yaml
+++ b/projects/mocops.yaml
@@ -8,7 +8,7 @@ spec:
     server: 'https://api.ocp-prod.massopen.cloud:6443'
   sourceRepos:
     - 'https://github.com/CCI-MOC/*'
-    - 'git@github.com:CCI-MOC/*'
+    - 'ssh://git@github.com/CCI-MOC/*'
   clusterResourceWhitelist:
   - group: '*'
     kind: '*'

--- a/projects/mocops.yaml
+++ b/projects/mocops.yaml
@@ -8,6 +8,7 @@ spec:
     server: 'https://api.ocp-prod.massopen.cloud:6443'
   sourceRepos:
     - 'https://github.com/CCI-MOC/*'
+    - 'git@github.com:CCI-MOC/*'
   clusterResourceWhitelist:
   - group: '*'
     kind: '*'


### PR DESCRIPTION
- Permit mocops project access to CCI-MOC repos via ssh
- Use ssh:// urls instead of user@host:/path urls
