### PR TITLE
Use ssh:// urls instead of user@host:/path urls

### DIFF
--- a/projects/mocops.yaml
+++ b/projects/mocops.yaml
@@ -8,7 +8,7 @@ spec:
     server: 'https://api.ocp-prod.massopen.cloud:6443'
   sourceRepos:
     - 'https://github.com/CCI-MOC/*'
-    - 'git@github.com:CCI-MOC/*'
+    - 'ssh://git@github.com/CCI-MOC/*'
   clusterResourceWhitelist:
   - group: '*'
     kind: '*'


### PR DESCRIPTION
When trying to access a private repository, argo is failing with:

    rpc error: code = Unknown desc = error creating SSH agent: "SSH
    agent requested but SSH_AUTH_SOCK not-specified"

There is a comment in [1] that suggests this can be resolved by using
a different URL format.

[1]: https://github.com/argoproj/argo-cd/issues/1172#issuecomment-767310738
